### PR TITLE
expose line and paragraph publicly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,4 @@ mod wikitext;
 pub use error::{ParserError, ParserErrorKind};
 pub use parser::parse_wikitext;
 pub use tokenizer::TextPosition;
-pub use wikitext::{Attribute, Headline, Section, Text, TextFormatting, TextPiece, Wikitext};
+pub use wikitext::{Attribute, Headline, Section, Text, TextFormatting, TextPiece, Wikitext, Line, Paragraph};


### PR DESCRIPTION
these types may be needed by match statements or inputs for functions